### PR TITLE
incorporating strip-toc.xsl into htmlmaker

### DIFF
--- a/htmlmaker.rb
+++ b/htmlmaker.rb
@@ -19,6 +19,9 @@ nbspcontents = File.read("#{tmp_dir}\\#{filename}\\outputtmp.html")
 replace = nbspcontents.gsub(/&nbsp/,"&#160")
 File.open("#{tmp_dir}\\#{filename}\\outputtmp.html", "w") {|file| file.puts replace}
 
+# strip static toc from html
+`java -jar C:\\saxon\\saxon9pe.jar -s:#{tmp_dir}\\#{filename}\\outputtmp.html -xsl:S:\\resources\\bookmaker_scripts\\bookmaker_htmlmaker\\strip-toc.xsl -o:#{tmp_dir}\\#{filename}\\outputtmp.html`
+
 # TESTING
 
 # html file should exist


### PR DESCRIPTION
This addition will strip a manually-added toc from the converted html file, leaving only the auto-generated toc within the file.